### PR TITLE
Skip OAI list records the requester cannot view (fix WSOD on access-restricted content)

### DIFF
--- a/src/Plugin/rest/resource/OaiPmh.php
+++ b/src/Plugin/rest/resource/OaiPmh.php
@@ -469,6 +469,14 @@ class OaiPmh extends ResourceBase {
       $this->oaiEntity = $entity;
       $identifier = $this->buildIdentifier($entity);
       $this->loadEntity($identifier, TRUE);
+      // The cache table can reference an entity the current (anonymous) user
+      // cannot view, or one that has since been deleted. In both cases
+      // loadEntity() sets $this->entity to FALSE. Skip the record instead of
+      // calling getHeaderById() on FALSE, which fatals. This mirrors the FALSE
+      // handling getRecord() already performs for the GetRecord verb.
+      if (empty($this->entity)) {
+        continue;
+      }
       $this->response[$this->verb]['header'][] = $this->getHeaderById($identifier);
     }
     if (empty($this->response[$this->verb]['header'])) {
@@ -486,6 +494,14 @@ class OaiPmh extends ResourceBase {
       $this->oaiEntity = $entity;
       $identifier = $this->buildIdentifier($entity);
       $this->loadEntity($identifier, TRUE);
+      // The cache table can reference an entity the current (anonymous) user
+      // cannot view, or one that has since been deleted. In both cases
+      // loadEntity() sets $this->entity to FALSE. Skip the record instead of
+      // calling getRecordById() on FALSE, which fatals. This mirrors the FALSE
+      // handling getRecord() already performs for the GetRecord verb.
+      if (empty($this->entity)) {
+        continue;
+      }
       $this->response[$this->verb]['record'][] = $this->getRecordById($identifier);
     }
     if (empty($this->response[$this->verb]['record'])) {


### PR DESCRIPTION
## Problem

We've been having a cache poisoning problem due to how we use groups and accessc ontrol.  A full `ListRecords`/`ListIdentifiers` harvest fatals (WSOD) for anonymous harvesters whenever the OAI cache contains a **published but access-restricted** record (or one that has since been deleted):

```
Error: Call to a member function hasField() on false in
Drupal\rest_oai_pmh\Plugin\rest\resource\OaiPmh->getHeaderById() (line 553)
```

Rebuilding the cache doesn't seem to change anything.  Poisoned entries will get added back into the cache.

So here's a couple null checks.  This fixed the problem for us.